### PR TITLE
Backends: OpenGL3: Add compatibility of GL_VERSION for GL 2.x

### DIFF
--- a/template/gl3w.h
+++ b/template/gl3w.h
@@ -208,7 +208,13 @@ static int parse_version(void)
         return GL3W_ERROR_INIT;
     glGetIntegerv(GL_MAJOR_VERSION, &version.major);
     glGetIntegerv(GL_MINOR_VERSION, &version.minor);
-    if (version.major < 3)
+    if (version.major == 0 && version.minor == 0)
+    {
+        // Query GL_VERSION in desktop GL 2.x, the string will start with "<major>.<minor>"
+        const char* gl_version = (const char*)glGetString(GL_VERSION);
+        sscanf(gl_version, "%d.%d", &version.major, &version.minor);
+    }
+    if (version.major < 2)
         return GL3W_ERROR_OPENGL_VERSION;
     return GL3W_OK;
 }
@@ -232,7 +238,7 @@ int imgl3wInit2(GL3WGetProcAddressProc proc)
 
 int imgl3wIsSupported(int major, int minor)
 {
-    if (major < 3)
+    if (major < 2)
         return 0;
     if (version.major == major)
         return version.minor >= minor;


### PR DESCRIPTION
GL_MAJOR_VERSION and GL_MINOR_VERSION are available on GL 3.0 and above. So we have to parse GL_VERSION under GL 2.x

Reference https://www.khronos.org/opengl/wiki/OpenGL_Context#Context_information_queries
See https://github.com/ocornut/imgui/pull/6154