### PR TITLE
Renaming type to avoid LTO collision with actual gl3w.

### DIFF
--- a/gl3w_gen.py
+++ b/gl3w_gen.py
@@ -186,7 +186,7 @@ def main():
 
         strings = [
             '/* gl3w internal state */',
-            'union GL3WProcs {',
+            'union ImGL3WProcs {',
             '    GL3WglProc ptr[{0}];'.format(len(procs)),
             '    struct {'
         ]
@@ -194,7 +194,7 @@ def main():
         for proc in procs:
             strings.append('        {0: <{2}} {1};'.format('PFN{0}PROC'.format(proc.upper()), proc[2:], max_proc_len))
         strings.append('    } gl;')     # struct
-        strings.append('};')            # union GL3WProcs
+        strings.append('};')            # union ImGL3WProcs
         h_template = h_template.replace(strings[0], '\n'.join(strings))
 
         strings = ['/* OpenGL functions */']

--- a/template/gl3w.h
+++ b/template/gl3w.h
@@ -114,7 +114,7 @@ GL3W_API GL3WglProc imgl3wGetProcAddress(const char *proc);
 
 /* gl3w internal state */
 
-GL3W_API extern union GL3WProcs imgl3wProcs;
+GL3W_API extern union ImGL3WProcs imgl3wProcs;
 
 /* OpenGL functions */
 
@@ -258,7 +258,7 @@ GL3WglProc imgl3wGetProcAddress(const char *proc) { return get_proc(proc); }
 static const char *proc_names[] = {
 };
 
-GL3W_API union GL3WProcs imgl3wProcs;
+GL3W_API union ImGL3WProcs imgl3wProcs;
 
 static void load_procs(GL3WGetProcAddressProc proc)
 {


### PR DESCRIPTION
See https://github.com/ocornut/imgui/issues/6668 for details.